### PR TITLE
Package Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "karma start --single-run --browsers PhantomJS",
     "eslint": "./node_modules/.bin/eslint src/",
     "start": "./node_modules/.bin/webpack-dev-server --progress --colors --hot --inline",
-    "build": "./node_modules/.bin/babel src -d dist",
+    "build": "npm run build:dist",
+    "build:dist": "npm run build:clean && cross-env NODE_ENV=release ./node_modules/.bin/babel ./src --out-dir ./dist --ignore spec.js",
+    "build:clean": "rimraf ./dist",
     "postinstall": "npm run build"
   },
   "repository": {
@@ -35,6 +37,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "cross-env": "^3.1.4",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-plugin-import": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,13 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.3",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
     "react-hot-loader": "^1.3.0",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.0.1",
     "react-dom": "^15.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "start": "./node_modules/.bin/webpack-dev-server --progress --colors --hot --inline",
     "build": "npm run build:dist",
     "build:dist": "npm run build:clean && cross-env NODE_ENV=release ./node_modules/.bin/babel ./src --out-dir ./dist --ignore spec.js",
-    "build:clean": "rimraf ./dist",
-    "postinstall": "npm run build"
+    "build:clean": "rimraf ./dist"
   },
   "repository": {
     "type": "git",
@@ -29,14 +28,13 @@
   },
   "homepage": "https://github.com/Terminux/react-csv-downloader#readme",
   "devDependencies": {
-    "babel": "^6.3.26",
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
+    "babel-preset-stage-3": "^6.3.13",
     "cross-env": "^3.1.4",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^8.0.0",


### PR DESCRIPTION
I've been using this package for the last month in several projects but keep running into issues where postinstall doesn't work unless you have babel as a global.  This PR will address the following...

1.  react and react-dom should be PeerD to avoid conflicts when consuming package.  closes #10
2.  why force stage-0 when you don't need it.  I dropped it to stage-3.  closes #11 
3.  adjust build scripts so tests are not included in dist and remove postinstall as it was causing issues when installing in consuming apps.   

Can you publish the /dist folder to npm instead of having it try to build when its installed?